### PR TITLE
feat(metal): extend prepare-hardware with NIC, GRUB and NVMe quirks

### DIFF
--- a/.taskfiles/metal.yaml
+++ b/.taskfiles/metal.yaml
@@ -17,7 +17,7 @@ tasks:
 
   prepare-hardware:
     desc: >-
-      Apply hardware quirks to a physical machine (EEE off on Intel I219 NICs, unused NICs administratively down, visible GRUB menu)
+      Apply hardware quirks to a physical machine (NIC, GRUB and NVMe quirks; see scripts/metal/prepare-hardware.sh)
       (task metal:prepare-hardware HOST=192.168.2.201 SSH_USER=compute)
     requires:
       vars: [HOST, SSH_USER]

--- a/.taskfiles/metal.yaml
+++ b/.taskfiles/metal.yaml
@@ -17,7 +17,7 @@ tasks:
 
   prepare-hardware:
     desc: >-
-      Apply hardware quirks to a physical machine (EEE off on Intel I219 NICs)
+      Apply hardware quirks to a physical machine (EEE off on Intel I219 NICs, unused NICs administratively down)
       (task metal:prepare-hardware HOST=192.168.2.201 SSH_USER=compute)
     requires:
       vars: [HOST, SSH_USER]

--- a/.taskfiles/metal.yaml
+++ b/.taskfiles/metal.yaml
@@ -17,7 +17,7 @@ tasks:
 
   prepare-hardware:
     desc: >-
-      Apply hardware quirks to a physical machine (EEE off on Intel I219 NICs, unused NICs administratively down)
+      Apply hardware quirks to a physical machine (EEE off on Intel I219 NICs, unused NICs administratively down, visible GRUB menu)
       (task metal:prepare-hardware HOST=192.168.2.201 SSH_USER=compute)
     requires:
       vars: [HOST, SSH_USER]

--- a/scripts/metal/prepare-hardware.sh
+++ b/scripts/metal/prepare-hardware.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Apply hardware quirks to a bare-metal host. Currently: disable EEE on
-# Intel I219 NICs (e1000e), whose TX queue freezes under EEE Low Power Idle
-# ("Detected Hardware Unit Hang") and never recovers without a link reset.
+# Apply hardware quirks to a bare-metal host:
+#   - Disable EEE on Intel I219 NICs (e1000e), whose TX queue freezes under
+#     EEE Low Power Idle ("Detected Hardware Unit Hang") and never recovers
+#     without a link reset.
+#   - Administratively disable every physical NIC that does not hold the
+#     default route: unplugged ports flap and request DHCP forever, and a
+#     faulty PHY can even negotiate a link against its own echo.
 #
 # Usage: sudo bash prepare-hardware.sh
 
@@ -137,6 +141,51 @@ apply_e1000e_tx_offloads_quirk() {
     done
 }
 
+# Administratively disable (netplan activation-mode off) every physical
+# ethernet NIC other than the one holding the default route. Wireless and
+# virtual interfaces (bridges, macvtap...) are left untouched.
+disable_unused_nics() {
+    local primary
+    primary=$(ip route show default | awk '/^default/ {print $5; exit}')
+    if [[ -z "${primary}" ]]; then
+        echo "[ERROR] Could not determine the primary NIC (no default route)."
+        exit 1
+    fi
+
+    local interface unused=()
+    for interface in /sys/class/net/*; do
+        interface=$(basename "${interface}")
+        [[ -e "/sys/class/net/${interface}/device" ]] || continue
+        [[ -d "/sys/class/net/${interface}/wireless" ]] && continue
+        [[ "$(cat "/sys/class/net/${interface}/type")" == "1" ]] || continue
+        [[ "${interface}" == "${primary}" ]] && continue
+        unused+=("${interface}")
+    done
+
+    if [[ "${#unused[@]}" -eq 0 ]]; then
+        echo "[OK]  No unused physical NICs found, nothing to do."
+        return
+    fi
+
+    local netplan_file="/etc/netplan/60-disable-unused-nics.yaml"
+    echo "[...] Primary NIC is '${primary}'; disabling: ${unused[*]}"
+    {
+        echo "# Physical NICs without the default route are administratively down:"
+        echo "# unplugged ports flap and request DHCP forever, and a faulty PHY can"
+        echo "# even negotiate a link against its own echo."
+        echo "network:"
+        echo "  version: 2"
+        echo "  ethernets:"
+        for interface in "${unused[@]}"; do
+            echo "    ${interface}:"
+            echo "      activation-mode: \"off\""
+        done
+    } > "${netplan_file}"
+    chmod 600 "${netplan_file}"
+
+    run_step "Applying netplan configuration" netplan apply
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -144,5 +193,6 @@ echo "[...] Applying hardware quirks"
 
 apply_e1000e_eee_quirk
 # apply_e1000e_tx_offloads_quirk
+disable_unused_nics
 
 echo "[OK]  Hardware preparation complete."

--- a/scripts/metal/prepare-hardware.sh
+++ b/scripts/metal/prepare-hardware.sh
@@ -12,6 +12,8 @@ set -euo pipefail
 #     headless and their video output takes long to appear, so a visible
 #     window is the only chance to act on emergencies. Release upgrades
 #     reset this to hidden/0.
+#   - Cap NVMe APST latency on known-flaky SSD models whose controller
+#     locks up when entering deep power-saving states.
 #
 # Usage: sudo bash prepare-hardware.sh
 
@@ -211,6 +213,47 @@ configure_grub_menu() {
     run_step "Regenerating GRUB configuration" update-grub
 }
 
+# Cap the APST latency for NVMe SSDs whose controller locks up in deep
+# power-saving states. Only acts when a model from the known-flaky list is
+# present; the kernel parameter keeps the drive out of its deepest states.
+apply_nvme_apst_quirk() {
+    local flaky_models=("KINGSTON SNV3S")
+    local parameter="nvme_core.default_ps_max_latency_us=5500"
+    local grub_file="/etc/default/grub"
+
+    local model matched=""
+    for model in /sys/class/nvme/*/model; do
+        [[ -e "${model}" ]] || continue
+        model=$(<"${model}")
+        local flaky
+        for flaky in "${flaky_models[@]}"; do
+            if [[ "${model}" == "${flaky}"* ]]; then
+                matched="${model% *}"
+                break 2
+            fi
+        done
+    done
+
+    if [[ -z "${matched}" ]]; then
+        echo "[OK]  No flaky NVMe models found, nothing to do."
+        return
+    fi
+
+    if grep -q "nvme_core.default_ps_max_latency_us" "${grub_file}"; then
+        echo "[OK]  NVMe APST latency cap already present, nothing to do."
+        return
+    fi
+
+    echo "[...] Found flaky NVMe model: ${matched}"
+    run_step "Adding NVMe APST latency cap to GRUB cmdline" \
+        sed -i \
+            "s/^GRUB_CMDLINE_LINUX_DEFAULT=\"\(.*\)\"/GRUB_CMDLINE_LINUX_DEFAULT=\"\1 ${parameter}\"/" \
+            "${grub_file}"
+    sed -i 's/=" /="/' "${grub_file}"
+
+    run_step "Regenerating GRUB configuration" update-grub
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -220,5 +263,6 @@ apply_e1000e_eee_quirk
 # apply_e1000e_tx_offloads_quirk
 disable_unused_nics
 configure_grub_menu
+apply_nvme_apst_quirk
 
 echo "[OK]  Hardware preparation complete."

--- a/scripts/metal/prepare-hardware.sh
+++ b/scripts/metal/prepare-hardware.sh
@@ -15,6 +15,9 @@ set -euo pipefail
 #   - Cap NVMe APST latency on known-flaky SSD models whose controller
 #     locks up when entering deep power-saving states.
 #
+# It also reports, per hardware-dependent quirk, whether this host needs it
+# and whether it was applied or already in place.
+#
 # Usage: sudo bash prepare-hardware.sh
 
 # ---------------------------------------------------------------------------
@@ -115,35 +118,61 @@ EOF
         ethtool -K "${interface}" tso off gso off
 }
 
-# Find physical interfaces driven by e1000e and disable EEE on each one.
-# No-op on hosts without Intel I219 NICs (e.g. Realtek r8169 hosts).
-apply_e1000e_eee_quirk() {
-    local interface driver found=0
+# Return every physical interface driven by e1000e, one per line
+get_e1000e_interfaces() {
+    local interface
     for interface in /sys/class/net/*; do
         interface=$(basename "${interface}")
-        driver=$(get_interface_driver "${interface}")
-        if [[ "${driver}" == "e1000e" ]]; then
-            found=1
-            echo "[...] Found e1000e interface: ${interface}"
-            persist_eee_disabled "${interface}"
-            disable_eee_now "${interface}"
-        fi
+        [[ "$(get_interface_driver "${interface}")" == "e1000e" ]] && echo "${interface}"
     done
-    if [[ "${found}" -eq 0 ]]; then
-        echo "[OK]  No e1000e interfaces found, nothing to do."
+    return 0
+}
+
+# Count kernel log messages of a NIC TX queue freeze, the symptom the EEE
+# and TX-offload quirks address
+count_nic_hang_messages() {
+    journalctl -t kernel --no-pager 2>/dev/null \
+        | grep -cE "Detected Hardware Unit Hang|transmit queue [0-9]+ timed out" || true
+}
+
+# Disable EEE on every e1000e NIC, reporting first whether this host needs
+# the quirk and then whether it was applied or already in place.
+apply_e1000e_eee_quirk() {
+    local interfaces hangs
+    interfaces=$(get_e1000e_interfaces)
+    hangs=$(count_nic_hang_messages)
+
+    if [[ -z "${interfaces}" ]]; then
+        if [[ "${hangs}" -gt 0 ]]; then
+            echo "[WARN] EEE quirk: not applicable (no e1000e NICs) but ${hangs} TX hang messages in the kernel log; another driver is hanging."
+        else
+            echo "[OK]  EEE quirk: not needed (no e1000e NICs)."
+        fi
+        return
     fi
+
+    echo "[NEED] EEE quirk: e1000e NIC(s) present ($(echo ${interfaces} | xargs)), ${hangs} TX hang messages in the kernel log."
+
+    local interface link_file dropin
+    for interface in ${interfaces}; do
+        link_file=$(udevadm info --query=property --property=ID_NET_LINK_FILE --value "/sys/class/net/${interface}" 2>/dev/null) || true
+        dropin="/etc/systemd/network/$(basename "${link_file:-none}").d/50-disable-eee.conf"
+        if [[ -f "${dropin}" ]] && ethtool --show-eee "${interface}" 2>/dev/null | grep -q "EEE status: disabled"; then
+            echo "[OK]  EEE quirk: already applied on '${interface}'."
+            continue
+        fi
+        persist_eee_disabled "${interface}"
+        disable_eee_now "${interface}"
+        echo "[DONE] EEE quirk: applied on '${interface}'."
+    done
 }
 
 # Disable TSO/GSO on every e1000e interface. Escalation quirk: enable only
 # on hosts where the hang persists with EEE already disabled.
 apply_e1000e_tx_offloads_quirk() {
-    local interface driver
-    for interface in /sys/class/net/*; do
-        interface=$(basename "${interface}")
-        driver=$(get_interface_driver "${interface}")
-        if [[ "${driver}" == "e1000e" ]]; then
-            disable_tx_offloads "${interface}"
-        fi
+    local interface
+    for interface in $(get_e1000e_interfaces); do
+        disable_tx_offloads "${interface}"
     done
 }
 
@@ -214,12 +243,17 @@ configure_grub_menu() {
 }
 
 # Cap the APST latency for NVMe SSDs whose controller locks up in deep
-# power-saving states. Only acts when a model from the known-flaky list is
-# present; the kernel parameter keeps the drive out of its deepest states.
+# power-saving states, reporting first whether this host needs the quirk
+# and then whether it was applied or already in place. The kernel log is
+# also scanned for lockup symptoms to flag models missing from the list.
 apply_nvme_apst_quirk() {
     local flaky_models=("KINGSTON SNV3S")
     local parameter="nvme_core.default_ps_max_latency_us=5500"
     local grub_file="/etc/default/grub"
+
+    local lockups
+    lockups=$(journalctl -t kernel --no-pager 2>/dev/null \
+        | grep -ciE "nvme.*(controller is down|resetting controller|probe failure|I/O timeout)" || true)
 
     local model matched=""
     for model in /sys/class/nvme/*/model; do
@@ -228,23 +262,28 @@ apply_nvme_apst_quirk() {
         local flaky
         for flaky in "${flaky_models[@]}"; do
             if [[ "${model}" == "${flaky}"* ]]; then
-                matched="${model% *}"
+                matched=$(echo "${model}" | xargs)
                 break 2
             fi
         done
     done
 
     if [[ -z "${matched}" ]]; then
-        echo "[OK]  No flaky NVMe models found, nothing to do."
+        if [[ "${lockups}" -gt 0 ]]; then
+            echo "[WARN] NVMe APST quirk: no known-flaky model, but ${lockups} controller lockup messages in the kernel log; consider adding this host's model to the flaky list."
+        else
+            echo "[OK]  NVMe APST quirk: not needed (no known-flaky NVMe models)."
+        fi
         return
     fi
+
+    echo "[NEED] NVMe APST quirk: flaky model present (${matched}), ${lockups} controller lockup messages in the kernel log."
 
     if grep -q "nvme_core.default_ps_max_latency_us" "${grub_file}"; then
-        echo "[OK]  NVMe APST latency cap already present, nothing to do."
+        echo "[OK]  NVMe APST quirk: already applied."
         return
     fi
 
-    echo "[...] Found flaky NVMe model: ${matched}"
     run_step "Adding NVMe APST latency cap to GRUB cmdline" \
         sed -i \
             "s/^GRUB_CMDLINE_LINUX_DEFAULT=\"\(.*\)\"/GRUB_CMDLINE_LINUX_DEFAULT=\"\1 ${parameter}\"/" \
@@ -252,6 +291,7 @@ apply_nvme_apst_quirk() {
     sed -i 's/=" /="/' "${grub_file}"
 
     run_step "Regenerating GRUB configuration" update-grub
+    echo "[DONE] NVMe APST quirk: applied (active after next reboot)."
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/metal/prepare-hardware.sh
+++ b/scripts/metal/prepare-hardware.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 #   - Administratively disable every physical NIC that does not hold the
 #     default route: unplugged ports flap and request DHCP forever, and a
 #     faulty PHY can even negotiate a link against its own echo.
+#   - Show the GRUB menu for a few seconds on boot: these machines run
+#     headless and their video output takes long to appear, so a visible
+#     window is the only chance to act on emergencies. Release upgrades
+#     reset this to hidden/0.
 #
 # Usage: sudo bash prepare-hardware.sh
 
@@ -186,6 +190,27 @@ disable_unused_nics() {
     run_step "Applying netplan configuration" netplan apply
 }
 
+# Make the GRUB menu visible for a few seconds on every boot, so a headless
+# machine offers a recovery window before the OS loads. Only regenerates the
+# GRUB config when the values actually change.
+configure_grub_menu() {
+    local grub_file="/etc/default/grub" timeout="10"
+
+    if grep -q "^GRUB_TIMEOUT_STYLE=menu$" "${grub_file}" \
+        && grep -q "^GRUB_TIMEOUT=${timeout}$" "${grub_file}"; then
+        echo "[OK]  GRUB menu already visible with timeout ${timeout}s, nothing to do."
+        return
+    fi
+
+    run_step "Setting GRUB menu visible with timeout ${timeout}s" \
+        sed -i \
+            -e "s/^GRUB_TIMEOUT_STYLE=.*/GRUB_TIMEOUT_STYLE=menu/" \
+            -e "s/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=${timeout}/" \
+            "${grub_file}"
+
+    run_step "Regenerating GRUB configuration" update-grub
+}
+
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -194,5 +219,6 @@ echo "[...] Applying hardware quirks"
 apply_e1000e_eee_quirk
 # apply_e1000e_tx_offloads_quirk
 disable_unused_nics
+configure_grub_menu
 
 echo "[OK]  Hardware preparation complete."


### PR DESCRIPTION
Extends the `metal:prepare-hardware` role with three quirks, all idempotent and no-op where the hardware does not need them:

- **Unused NICs administratively down** (netplan `activation-mode: off` for every physical NIC without the default route). Unplugged ports flap and request DHCP forever; on compute-10 a faulty PHY even negotiates 100Mbps against its own echo on an empty port.
- **GRUB menu visible with a 10s timeout**: release upgrades silently reset it to hidden/0, removing the only boot-time recovery window on headless machines.
- **NVMe APST latency cap** for known-flaky SSD models (currently the Kingston SNV3S of compute-10, whose controller locks up in deep power-saving states).

Each hardware-dependent quirk reports whether the host needs it (hardware match + symptom count from the kernel log) and whether it was applied or already in place. Hosts with symptoms but missing from the static lists are flagged with a warning.

Already applied and verified on compute-10/20/30.