### PR TITLE
feat(metal): split Cockpit into its own prepare-ui role

### DIFF
--- a/.taskfiles/metal.yaml
+++ b/.taskfiles/metal.yaml
@@ -39,6 +39,18 @@ tasks:
       - ssh {{._SSH_MUX_OPTS}} -t {{.SSH_USER}}@{{.HOST}} "sudo bash /tmp/prepare-hypervisor.sh {{.SSH_USER}}"
       - ssh {{._SSH_MUX_OPTS}} {{.SSH_USER}}@{{.HOST}} "rm -f /tmp/prepare-hypervisor.sh"
 
+  prepare-ui:
+    desc: >-
+      Install the Cockpit web UI on a remote host
+      (task metal:prepare-ui HOST=192.168.2.201 SSH_USER=compute)
+    requires:
+      vars: [HOST, SSH_USER]
+    interactive: true
+    cmds:
+      - scp {{._SSH_MUX_OPTS}} {{.PROJECT_DIR}}/scripts/metal/prepare-ui.sh {{.SSH_USER}}@{{.HOST}}:/tmp/prepare-ui.sh
+      - ssh {{._SSH_MUX_OPTS}} -t {{.SSH_USER}}@{{.HOST}} "sudo bash /tmp/prepare-ui.sh"
+      - ssh {{._SSH_MUX_OPTS}} {{.SSH_USER}}@{{.HOST}} "rm -f /tmp/prepare-ui.sh"
+
   prepare-collectors:
     desc: >-
       Install Prometheus node_exporter and smartctl_exporter as systemd services on a remote host
@@ -65,6 +77,8 @@ tasks:
       - task: prepare-hardware
         vars: { HOST: "{{.HOST}}", SSH_USER: "{{.SSH_USER}}" }
       - task: prepare-hypervisor
+        vars: { HOST: "{{.HOST}}", SSH_USER: "{{.SSH_USER}}" }
+      - task: prepare-ui
         vars: { HOST: "{{.HOST}}", SSH_USER: "{{.SSH_USER}}" }
       - task: prepare-collectors
         vars: { HOST: "{{.HOST}}", SSH_USER: "{{.SSH_USER}}" }

--- a/scripts/metal/prepare-hypervisor.sh
+++ b/scripts/metal/prepare-hypervisor.sh
@@ -128,17 +128,6 @@ restart_libvirt() {
         systemctl restart libvirtd
 }
 
-# Install Cockpit with the virtual-machine management plugin
-# NOTE: no '--no-install-recommends' here on purpose: 'cockpit' is a
-# metapackage whose actual components (cockpit-ws, cockpit-system...) are
-# pulled in via Recommends.
-install_cockpit() {
-    run_step "Installing Cockpit and cockpit-machines" \
-        apt-get --quiet install \
-            cockpit \
-            cockpit-machines
-}
-
 # ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
@@ -151,6 +140,5 @@ install_virtualization_packages
 add_user_to_libvirt_group
 disable_qemu_security_driver
 restart_libvirt
-install_cockpit
 
 echo "[OK]  Hypervisor preparation complete."

--- a/scripts/metal/prepare-ui.sh
+++ b/scripts/metal/prepare-ui.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the Cockpit web UI with the virtual-machine management plugin.
+# Kept as its own role so the UI can eventually live on a dedicated machine
+# instead of one instance per hypervisor.
+#
+# Usage: sudo bash prepare-ui.sh
+
+# ---------------------------------------------------------------------------
+# Guard: must run as root
+# ---------------------------------------------------------------------------
+if [[ "${EUID}" -ne 0 ]]; then
+    echo "[ERROR] This script must be run as root."
+    echo "        Usage: sudo bash $0"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helper: run_step <description> <command> [args...]
+# Prints a progress line, runs the command, and exits with a clear [ERROR]
+# message on failure. Safe to use with set -euo pipefail.
+# ---------------------------------------------------------------------------
+run_step() {
+    local description="$1"
+    shift
+    echo "[...] ${description}"
+    local exit_code=0
+    "$@" || exit_code=$?
+    if [[ "${exit_code}" -ne 0 ]]; then
+        echo "[ERROR] Failed: ${description}"
+        exit "${exit_code}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Step functions
+# ---------------------------------------------------------------------------
+
+# Update the package lists
+update_packages_list() {
+    run_step "Updating package lists" apt-get --quiet update
+}
+
+# Install Cockpit with the virtual-machine management plugin
+# NOTE: no '--no-install-recommends' here on purpose: 'cockpit' is a
+# metapackage whose actual components (cockpit-ws, cockpit-system...) are
+# pulled in via Recommends. The exception is cockpit-networkmanager, vetoed
+# because it drags NetworkManager into networkd-managed hosts.
+install_cockpit() {
+    run_step "Installing Cockpit and cockpit-machines" \
+        apt-get --quiet install \
+            cockpit \
+            cockpit-machines \
+            cockpit-networkmanager-
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+echo "[...] Preparing UI"
+
+update_packages_list
+install_cockpit
+
+echo "[OK]  UI preparation complete."


### PR DESCRIPTION
Moves the Cockpit install out of `prepare-hypervisor` into a new `metal:prepare-ui` role, so the UI can eventually live on a dedicated machine instead of one instance per hypervisor. For now `prepare-machine` chains it after `prepare-hypervisor`, keeping current behaviour.

The role also vetoes the `cockpit-networkmanager` recommend, which drags the NetworkManager stack into networkd-managed hosts.